### PR TITLE
Add epp file type

### DIFF
--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -1,6 +1,7 @@
 'scopeName': 'source.puppet'
 'fileTypes': [
-  'pp'
+  'pp',
+  'epp'
 ]
 'foldingStartMarker': '(^\\s*/\\*|(\\{|\\[|\\()\\s*$)'
 'foldingStopMarker': '(\\*/|^\\s*(\\}|\\]|\\)))'


### PR DESCRIPTION
Added epp file type for Embedded Puppet templating language to show
syntax hightlighting.

demo:
![first open source contribution 2](https://cloud.githubusercontent.com/assets/10424206/14294505/ff141cb2-fb8a-11e5-86d7-f2055440dff9.PNG)
